### PR TITLE
Disable a few more contentious linting practices

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,3 +1,18 @@
+Lint/AssignmentInCondition:
+  Enabled: false
+
+Lint/HandleExceptions:
+  Enabled: false
+
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: false
+
+Lint/UnusedBlockArgument:
+  Enabled: false
+
+Lint/UselessAssignment:
+  Enabled: false
+
 Metrics/LineLength:
   Enabled: false
 


### PR DESCRIPTION
There's a few things that we do in a few places, and it really isn't /that/ bad, or at least sure beats the alternative to make code fit an ugly regimen. 